### PR TITLE
Fix wrong path to dpu-bmc-upgrade file in Debian rules

### DIFF
--- a/bf-release.spec
+++ b/bf-release.spec
@@ -51,10 +51,12 @@ echo ${BF_VERSION} > %{buildroot}/etc/mlnx-release
 # Tools
 install -d %{buildroot}/opt/mellanox/hlk
 install -d %{buildroot}/sbin
+install -d %{buildroot}/%{_sbindir}
 
 install -m 0755	src/mlnx-pre-hlk     %{buildroot}/opt/mellanox/hlk/mlnx-pre-hlk
 install -m 0755	src/mlnx-post-hlk    %{buildroot}/opt/mellanox/hlk/mlnx-post-hlk
 install -m 0755	src/kexec_reboot     %{buildroot}/sbin/kexec_reboot
+install -m 0755	src/dpu-bmc-upgrade  %{buildroot}/%{_sbindir}/dpu-bmc-upgrade
 
 # Sysctl
 install -d %{buildroot}/usr/lib/sysctl.d/
@@ -332,6 +334,7 @@ fi
 /opt/mellanox/hlk/*
 
 /sbin/kexec_reboot
+%{_sbindir}/dpu-bmc-upgrade
 
 /usr/lib/sysctl.d/*
 /lib/udev/rules.d/*

--- a/debian/rules
+++ b/debian/rules
@@ -123,7 +123,7 @@ endif
 	# ISO post-installation script
 	install -d debian/$(pname)/usr/sbin/
 	install -m 0755 src/iso/bfiso-post-install.sh debian/$(pname)/usr/sbin/bfiso-post-install.sh
-	install -m 0755 src/iso/dpu-bmc-upgrade debian/$(pname)/usr/sbin/dpu-bmc-upgrade
+	install -m 0755 src/dpu-bmc-upgrade debian/$(pname)/usr/sbin/dpu-bmc-upgrade
 
 	# BFB Info
 	install -m 0755	src/bfb-info           debian/$(pname)/usr/bin/bfb-info

--- a/debian/rules
+++ b/debian/rules
@@ -123,6 +123,7 @@ endif
 	# ISO post-installation script
 	install -d debian/$(pname)/usr/sbin/
 	install -m 0755 src/iso/bfiso-post-install.sh debian/$(pname)/usr/sbin/bfiso-post-install.sh
+	install -m 0755 src/iso/dpu-bmc-upgrade debian/$(pname)/usr/sbin/dpu-bmc-upgrade
 
 	# BFB Info
 	install -m 0755	src/bfb-info           debian/$(pname)/usr/bin/bfb-info

--- a/src/bf-upgrade.env/atf-uefi
+++ b/src/bf-upgrade.env/atf-uefi
@@ -1,3 +1,5 @@
+UPDATE_ATF_UEFI=${UPDATE_ATF_UEFI:-"yes"}
+
 update_atf_uefi()
 {
 	if function_exists pre_update_atf_uefi; then

--- a/src/bf-upgrade.env/bmc
+++ b/src/bf-upgrade.env/bmc
@@ -527,7 +527,9 @@ bmc_components_update()
 				bmc_reboot_from_dpu
 			fi
 			ilog "INFO: Running BMC components update flow"
-			create_vlan
+			if ! (ping -c 3 $BMC_IP > /dev/null 2>&1); then
+				create_vlan
+			fi
 			# get_bmc_public_key
 			if [ "$BMC_LINK_UP" == "yes" ]; then
 				if [ ! -z "$NEW_BMC_PASSWORD" ]; then

--- a/src/dpu-bmc-upgrade
+++ b/src/dpu-bmc-upgrade
@@ -1,0 +1,112 @@
+#!/bin/bash
+###############################################################################
+#
+# Copyright 2024 NVIDIA Corporation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+###############################################################################
+
+# Source a configuration if exists.
+CONFIG=${CONFIG:-"/etc/dpu-bmc-upgrade.conf"}
+[ -f "$CONFIG" ] && source "$CONFIG"
+
+SCRIPTS_DIR="/etc/acpi/actions"
+
+ATF_UEFI_IMAGE=${ATF_UEFI_IMAGE:-"/lib/firmware/mellanox/boot/capsule/boot_update2.cap"}
+NIC_FW_GI_PATH=${NIC_FW_GI_PATH:-"/lib/firmware/mellanox/bmc"}
+DPU_GI_PATH=${DPU_GI_PATH:-"/lib/firmware/mellanox/bmc"}
+BMC_PATH=${BMC_PATH:-"/lib/firmware/mellanox/bmc"}
+CEC_PATH=${CEC_PATH:-"/lib/firmware/mellanox/cec"}
+
+if (lspci -n -d 15b3: | grep -wq 'a2dc'); then
+	BMC_IMAGE=${BMC_IMAGE:-"$(/bin/ls ${BMC_PATH}/bf3-bmc*.fwpkg)"}
+	CEC_IMAGE=${CEC_IMAGE:-"$(/bin/ls ${CEC_PATH}/*cec-fw.bin)"}
+	NIC_FW_GOLDEN_IMAGE=${NIC_FW_GOLDEN_IMAGE:-"$(/bin/ls ${NIC_FW_GI_PATH}/fw*.bfb)"}
+	DPU_GOLDEN_IMAGE=${DPU_GOLDEN_IMAGE:-"$(/bin/ls ${DPU_GI_PATH}/bf3*preboot*.bfb)"}
+elif (lspci -n -d 15b3: | grep -wq 'a2d6'); then
+	BMC_IMAGE=${BMC_IMAGE:-"$(/bin/ls ${BMC_PATH}/bf2-bmc*.tar)"}
+	CEC_IMAGE=${CEC_IMAGE:-"$(/bin/ls ${CEC_PATH}/*cec-fw.bin)"}
+	NIC_FW_GOLDEN_IMAGE=""
+	DPU_GOLDEN_IMAGE=""
+fi
+
+BMC_IMAGE=${BMC_IMAGE:-"$(/bin/ls ${BMC_PATH}/bf3-bmc*.fwpkg)"}
+CEC_IMAGE=${CEC_IMAGE:-"$(/bin/ls ${CEC_PATH}/bf3-cec-fw.bin)"}
+NIC_FW_GOLDEN_IMAGE=${NIC_FW_GOLDEN_IMAGE:-"$(/bin/ls ${NIC_FW_GI_PATH}/fw*.bin)"}
+DPU_GOLDEN_IMAGE=${DPU_GOLDEN_IMAGE:-"$(/bin/ls ${DPU_GI_PATH}/bf3*preboot*.bfb)"}
+
+# Include scripts that provide upgrade infrastructure
+if (bash -n ${SCRIPTS_DIR}/bf-upgrade.env/common 2>/dev/null); then
+	. ${SCRIPTS_DIR}/bf-upgrade.env/common
+fi
+
+if (bash -n ${SCRIPTS_DIR}/bf-upgrade.env/atf-uefi 2>/dev/null); then
+	. ${SCRIPTS_DIR}/bf-upgrade.env/atf-uefi
+fi
+
+if (bash -n ${SCRIPTS_DIR}/bf-upgrade.env/nic-fw 2>/dev/null); then
+	. ${SCRIPTS_DIR}/bf-upgrade.env/nic-fw
+fi
+
+if (bash -n ${SCRIPTS_DIR}/bf-upgrade.env/bmc 2>/dev/null); then
+	. ${SCRIPTS_DIR}/bf-upgrade.env/bmc
+fi
+
+if [ "$UPDATE_ATF_UEFI" == "yes" ]; then
+	if [ -e "${ATF_UEFI_IMAGE}" ]; then
+		if function_exists update_atf_uefi; then
+			update_atf_uefi "${ATF_UEFI_IMAGE}"
+		else
+			log  "ERROR: BSP upgrade function does not exist"
+		fi
+	else
+		log "ERROR: BSP upgrade capsule ${ATF_UEFI_IMAGE} was not found"
+		UPDATE_ATF_UEFI="no"
+	fi
+fi
+
+if [ "$UPDATE_BMC_FW" == "yes" ]; then
+	if [ ! -e "${BMC_IMAGE}" ]; then
+		log "ERROR: BMC firmware ${BMC_IMAGE} was not found"
+		UPDATE_BMC_FW="no"
+	fi
+fi
+
+if [ "$UPDATE_CEC_FW" == "yes" ]; then
+	if [ ! -e "${CEC_IMAGE}" ]; then
+		log "ERROR: CEC firmware ${CEC_IMAGE} was not found"
+		UPDATE_CEC_FW="no"
+	fi
+fi
+
+if [ "$UPDATE_NIC_FW_GOLDEN_IMAGE" == "yes" ]; then
+	if [ ! -e "${NIC_FW_GOLDEN_IMAGE}" ]; then
+		log "ERROR: NIC firmware golden image ${NIC_FW_GOLDEN_IMAGE} was not found"
+		UPDATE_NIC_FW_GOLDEN_IMAGE="no"
+	fi
+fi
+
+if function_exists update_atf_uefi; then
+	bmc_components_update
+else
+	log  "ERROR: BMC upgrade function does not exist"
+fi
+
+log "Runtime upgrade finished"
+sleep 3


### PR DESCRIPTION
Debian rules file pointed to a non-existing path.

This change corrects the path.